### PR TITLE
Stylowanie nawigacji pt2

### DIFF
--- a/src/common/Navigation/index.js
+++ b/src/common/Navigation/index.js
@@ -1,26 +1,28 @@
-import { Logotype, NavbarContainer, StyledNavbar, StyledNavLink, StyledPageTitle, StyledCameraIcon, StyledSearchBox, NavbarWrapper } from "./styled"
+import { Logotype, NavbarContainer, StyledNavbar, StyledNavLink, StyledPageTitle, StyledCameraIcon, StyledSearchBox, NavbarWrapper, BlackBar } from "./styled"
 
 
 export const Navigation = () => {
 
     return (
-        <NavbarContainer>
-            <NavbarWrapper>
-                <Logotype>
-                    <StyledCameraIcon />
-                    <StyledPageTitle>Movies Browser</StyledPageTitle>
-                </Logotype>
-                <StyledNavbar>
+        <BlackBar>
+            <NavbarContainer>
+                <NavbarWrapper>
+                    <Logotype>
+                        <StyledCameraIcon />
+                        <StyledPageTitle>Movies Browser</StyledPageTitle>
+                    </Logotype>
+                    <StyledNavbar>
 
-                    <li>
-                        <StyledNavLink to="/movies">MOVIES</StyledNavLink>
-                    </li>
-                    <li>
-                        <StyledNavLink to="/people">PEOPLE</StyledNavLink>
-                    </li>
-                </StyledNavbar>
-            </NavbarWrapper>
-            <StyledSearchBox placeholder="Search for movies..." />
-        </NavbarContainer>
+                        <li>
+                            <StyledNavLink to="/movies">MOVIES</StyledNavLink>
+                        </li>
+                        <li>
+                            <StyledNavLink to="/people">PEOPLE</StyledNavLink>
+                        </li>
+                    </StyledNavbar>
+                </NavbarWrapper>
+                <StyledSearchBox placeholder="Search for movies..." />
+            </NavbarContainer>
+        </BlackBar>
     )
 };

--- a/src/common/Navigation/styled.js
+++ b/src/common/Navigation/styled.js
@@ -3,13 +3,78 @@ import styled from "styled-components";
 import { ReactComponent as CameraIcon } from "../../images/camera.svg"
 import img from "../../images/search.svg";
 
-export const NavbarContainer = styled.nav`
-    min-height: 94px;
+export const BlackBar = styled.div`
     display: flex;
-    justify-content: space-evenly;
-    align-items: center;
+    justify-content: center;
     background-color: ${({ theme }) => theme.color.black};
+`;
+
+export const NavbarContainer = styled.nav`
+    width: 1368px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: inherit;
     flex-wrap: wrap;
+`;
+
+export const NavbarWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    @media(max-width: 860px) {
+        width: 90vw;
+        margin-top: 0;
+        flex-grow: 1;
+    }
+`;
+
+export const Logotype = styled.span`
+    display: flex;
+    align-items: center;
+    margin: 27px 16px;
+
+    @media(max-width: 860px) {
+        margin-bottom: 18px;
+    }
+`;
+
+export const StyledCameraIcon = styled(CameraIcon)`
+    path {
+        stroke-width: 2.5;
+    }
+    g {
+        opacity: 1;
+    }
+    width: 40px;
+    height: 40px;
+
+    @media(max-width: 860px) {
+        width: 20px;
+        height: 21px;
+    }
+`;
+
+export const StyledPageTitle = styled.h1`
+    padding: 0 5vw 0 16px;
+    font-weight: 500;
+    font-size: 23px;
+    line-height: 40px;
+    letter-spacing: -1.5px;
+    white-space: nowrap;
+    margin: 0;
+
+    color: ${({ theme }) => theme.color.white};
+
+    @media(max-width: 860px) {
+        height: 17px;
+        font-size: 13px;
+        line-height: 16.9px;
+        letter-spacing: -0.5px;
+        margin: 0;
+        padding: 0 0 0 16px;
+}
 `;
 
 export const StyledNavbar = styled.ul`
@@ -19,19 +84,12 @@ export const StyledNavbar = styled.ul`
 
     @media(max-width: 860px) {
         padding: 0;
-    }
-`;
-
-export const NavbarWrapper = styled.div`
-    display: flex;
-
-    @media(max-width: 860px) {
-        padding: 0;
+        margin: 16px 28px 6px 0;
     }
 `;
 
 export const StyledNavLink = styled(NavLink)`
-    padding: 8px 24px;
+    padding: 13.5px 24px;
     text-decoration: none;
     color: ${({ theme }) => theme.color.white};
     font-size: 14px;
@@ -44,61 +102,22 @@ export const StyledNavLink = styled(NavLink)`
     @media(max-width: 860px) {
         display: flex;
         align-items: center;
-        padding: 8px 1vw;
-        margin: 0 1vw;
+        justify-content: flex-end;
+        padding: 8px 12px;
         border-radius: 29px;
         font-size: 12px;
         line-height: 18px;
 }
 `;
 
-export const StyledCameraIcon = styled(CameraIcon)`
-    path {
-        stroke-width: 2.5;
-    }
-    g {
-        opacity: 1;
-    }
-
-    @media(max-width: 860px) {
-        path {
-            stroke-width: 1.06;
-        }
-        width: 20px;
-        height: 21px;
-    }
-`;
-
-export const StyledPageTitle = styled.h1`
-    padding: 0 5vw 0 16px;
-    font-weight: 500;
-    font-size: 24px;
-    letter-spacing: -1.5px;
-    white-space: nowrap;
-
-    color: ${({ theme }) => theme.color.white};
-
-    @media(max-width: 860px) {
-        width: 95px;
-        height: 17px;
-        font-size: 13px;
-        line-height: 130%;
-        letter-spacing: -0.5px;
-}
-`;
-
-export const Logotype = styled.span`
-    display: flex;
-    align-items: center;
-`;
-
 export const StyledSearchBox = styled.input`
     border: 1px solid ${({ theme }) => theme.color.gray};
     border-radius: 33px;
     height: 48px;
-    width: 25vw;
     min-width: 282px;
-    text-indent: 17%;
+    width: 22.5vw;
+    margin: 16px;
+    text-indent: 60px;
 
     background-image: url(${img});
     background-size: 20px 20px;
@@ -110,13 +129,15 @@ export const StyledSearchBox = styled.input`
     }
 
     @media(max-width: 860px) {
-        max-width: 90vw;
-        margin: 16px 0px;
+        width: 90vw;
+        height: 44px;
         padding: 0px;
-        text-indent: 14%;
+        text-indent: 40px;
         background-position: 17px center;
         background-size: 14px 14px;
         font-size: 13px;
+        display: flex;
+        flex-grow: 1;
 }
 `;
 

--- a/src/common/Navigation/styled.js
+++ b/src/common/Navigation/styled.js
@@ -14,18 +14,15 @@ export const NavbarContainer = styled.nav`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background-color: inherit;
     flex-wrap: wrap;
 `;
 
 export const NavbarWrapper = styled.div`
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-
+    
     @media(max-width: 860px) {
-        width: 90vw;
-        margin-top: 0;
+
+        justify-content: space-between;
         flex-grow: 1;
     }
 `;
@@ -68,11 +65,10 @@ export const StyledPageTitle = styled.h1`
     color: ${({ theme }) => theme.color.white};
 
     @media(max-width: 860px) {
-        height: 17px;
+        
         font-size: 13px;
         line-height: 16.9px;
         letter-spacing: -0.5px;
-        margin: 0;
         padding: 0 0 0 16px;
 }
 `;
@@ -100,11 +96,8 @@ export const StyledNavLink = styled(NavLink)`
     }
 
     @media(max-width: 860px) {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
+        display: block;
         padding: 8px 12px;
-        border-radius: 29px;
         font-size: 12px;
         line-height: 18px;
 }
@@ -131,7 +124,6 @@ export const StyledSearchBox = styled.input`
     @media(max-width: 860px) {
         width: 90vw;
         height: 44px;
-        padding: 0px;
         text-indent: 40px;
         background-position: 17px center;
         background-size: 14px 14px;


### PR DESCRIPTION
* Fixed what border-box changed
* I decided to use the same svg camera icon for both mobile and normal resolutions, just tweaked the styling a little bit
* Space-evenly for logotype+navigation is changed to space-between and it's width is adjusted to scrollbar size which is now occupying whole available space on mobiles
* Adjusted padding and letter spacings to reflect better what's on figma
* Solid padding from the magnifying-glass svg in search bar
* Decided NOT to do the continuous scaling of Movies Browser title.
* MOVIES/PEOPLE are adjusted to reflect what's on figma
* Added a container above the whole navigation, so that I could pass the max-width: 1368px to navigation, this solution was way more elegant than adding margins(even flexible).